### PR TITLE
Create a basic Feature abstraction

### DIFF
--- a/core/configuration/src/main/kotlin/features/Feature.kt
+++ b/core/configuration/src/main/kotlin/features/Feature.kt
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2022 AndroidDev Discord Dev Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package features
+
+/**
+ * A basic interface for defining a "feature". Features must have an entrypoint [init] configured.
+ */
+interface Feature {
+
+    /**
+     * Initialises the feature. This is a good place to do things like register commands, initialise state based on
+     * settings etc.
+     */
+    suspend fun init()
+}

--- a/core/configuration/src/main/kotlin/features/RegisterFeatures.kt
+++ b/core/configuration/src/main/kotlin/features/RegisterFeatures.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright 2022 AndroidDev Discord Dev Team
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package features
+
+/**
+ * Initialises a number of features. This is a convenience function to avoid calling [Feature.init] repeatedly.
+ */
+suspend fun initFeatures(vararg features: Feature) {
+    features.forEach {
+        it.init()
+    }
+}

--- a/core/configuration/src/main/kotlin/features/RegisterFeatures.kt
+++ b/core/configuration/src/main/kotlin/features/RegisterFeatures.kt
@@ -15,11 +15,16 @@
  */
 package features
 
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.supervisorScope
+
 /**
- * Initialises a number of features. This is a convenience function to avoid calling [Feature.init] repeatedly.
+ * Initialises a number of features asynchronously.
  */
-suspend fun initFeatures(vararg features: Feature) {
+suspend fun initFeatures(vararg features: Feature): Unit = supervisorScope {
     features.forEach {
-        it.init()
+        launch {
+            it.init()
+        }
     }
 }


### PR DESCRIPTION
This aims to simplify feature setup. Features can now be self-contained classes with a suspending initialisation step. We can avoid calling `init` for every feature by using `initFeatures()`