### PR TITLE
Properly implement command callbacks

### DIFF
--- a/core/discord/src/main/kotlin/interaction/ApplicationCommandScope.kt
+++ b/core/discord/src/main/kotlin/interaction/ApplicationCommandScope.kt
@@ -27,12 +27,25 @@ interface ApplicationCommandScope {
      * @param description A short description of the command. This will be displayed to users next to the name.
      * @param onCommandInvoked Called when the command was invoked by the user. That is, when a new interaction is
      * initiated. See [InteractionScope].
-     * @param builder The command builder. See [ChatInputCommandBuilder].
+     * @param builder The command builder. See [CommandBuilder].
      */
     suspend fun registerGlobalChatInputCommand(
         name: String,
         description: String,
         onCommandInvoked: suspend InteractionScope.() -> Unit,
-        builder: ChatInputCommandBuilder.() -> Unit,
+        builder: CommandBuilder.() -> Unit,
+    )
+
+    /**
+     * Registers a new global chat input command. A "global chat input command" is a slash command that can be used
+     * anywhere.
+     * @param name The name of the command. This will be what users type to invoke the command.
+     * @param description A short description of the command. This will be displayed to users next to the name.
+     * @param builder The command builder. See [CommandBuilder].
+     */
+    suspend fun registerGlobalChatInputCommandGroup(
+        name: String,
+        description: String,
+        builder: CommandGroupBuilder.() -> Unit,
     )
 }

--- a/core/discord/src/main/kotlin/interaction/ChatInputCommandBuilder.kt
+++ b/core/discord/src/main/kotlin/interaction/ChatInputCommandBuilder.kt
@@ -21,9 +21,16 @@ interface CommandGroupBuilder {
      * Configures a new subcommand under this command.
      * @param name The name of the subcommand. This will be what users type to invoke the command.
      * @param description A short description of the subcommand. This will be displayed to users next to the name.
+     * @param onCommandInvoked Called when the command was invoked by the user. That is, when a new interaction is
+     * initiated. See [InteractionScope].
      * @param builder The command builder. See [SubCommandBuilder].
      */
-    fun subCommand(name: String, description: String, builder: SubCommandBuilder.() -> Unit)
+    fun subCommand(
+        name: String,
+        description: String,
+        onCommandInvoked: suspend InteractionScope.() -> Unit,
+        builder: SubCommandBuilder.() -> Unit
+    )
 
     /**
      * Configures a new subcommand group under this command.
@@ -115,9 +122,16 @@ interface SubCommandGroupBuilder {
      * Configures a new subcommand under this command.
      * @param name The name of the subcommand. This will be what users type to invoke the command.
      * @param description A short description of the subcommand. This will be displayed to users next to the name.
+     * @param onCommandInvoked Called when the command was invoked by the user. That is, when a new interaction is
+     * initiated. See [InteractionScope].
      * @param builder The command builder. See [SubCommandBuilder].
      */
-    fun subCommand(name: String, description: String, builder: SubCommandBuilder.() -> Unit)
+    fun subCommand(
+        name: String,
+        description: String,
+        onCommandInvoked: suspend InteractionScope.() -> Unit,
+        builder: SubCommandBuilder.() -> Unit
+    )
 }
 
 @DslMarker

--- a/core/discord/src/main/kotlin/interaction/ChatInputCommandBuilder.kt
+++ b/core/discord/src/main/kotlin/interaction/ChatInputCommandBuilder.kt
@@ -29,7 +29,7 @@ interface CommandGroupBuilder {
         name: String,
         description: String,
         onCommandInvoked: suspend InteractionScope.() -> Unit,
-        builder: SubCommandBuilder.() -> Unit
+        builder: SubCommandBuilder.() -> Unit,
     )
 
     /**
@@ -130,7 +130,7 @@ interface SubCommandGroupBuilder {
         name: String,
         description: String,
         onCommandInvoked: suspend InteractionScope.() -> Unit,
-        builder: SubCommandBuilder.() -> Unit
+        builder: SubCommandBuilder.() -> Unit,
     )
 }
 

--- a/core/discord/src/main/kotlin/interaction/ChatInputCommandBuilder.kt
+++ b/core/discord/src/main/kotlin/interaction/ChatInputCommandBuilder.kt
@@ -15,13 +15,8 @@
  */
 package interaction
 
-/**
- * A builder for chat input commands. Supports all [CommandBuilder] options, as well as configuring subcommands and
- * subcommand groups.
- */
 @ChatInputCommandBuilderMarker
-interface ChatInputCommandBuilder : CommandBuilder {
-
+interface CommandGroupBuilder {
     /**
      * Configures a new subcommand under this command.
      * @param name The name of the subcommand. This will be what users type to invoke the command.

--- a/core/discord/src/main/kotlin/interaction/InteractionScope.kt
+++ b/core/discord/src/main/kotlin/interaction/InteractionScope.kt
@@ -21,6 +21,16 @@ package interaction
 interface InteractionScope {
 
     /**
+     * The ID of the guild the interaction originated from. This will be null if the interaction originated from DMs.
+     */
+    val sourceGuildId: String?
+
+    /**
+     * The ID of the channel the interaction originated from.
+     */
+    val sourceChannelId: String
+
+    /**
      * Writes a basic message in response to an interaction.
      * @param targetChannelId The ID of the channel to write the message to.
      * @param ephemeral Whether the message is "ephemeral". An ephemeral message is a message only the user who

--- a/core/discord/src/main/kotlin/interaction/InteractionScope.kt
+++ b/core/discord/src/main/kotlin/interaction/InteractionScope.kt
@@ -30,4 +30,9 @@ interface InteractionScope {
      * @param content The text content for the message.
      */
     suspend fun createResponseMessage(targetChannelId: String, ephemeral: Boolean, content: String)
+
+    /**
+     * Retrieves the channel ID of a channel option with the given name.
+     */
+    fun getChannelId(optionName: String): String
 }

--- a/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
@@ -19,7 +19,8 @@ import dev.kord.gateway.Gateway
 import dev.kord.gateway.InteractionCreate
 import dev.kord.rest.service.RestClient
 import interaction.ApplicationCommandScope
-import interaction.ChatInputCommandBuilder
+import interaction.CommandBuilder
+import interaction.CommandGroupBuilder
 import interaction.InteractionScope
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.flow.collectLatest
@@ -35,13 +36,13 @@ internal class KordApplicationCommandScope(
         name: String,
         description: String,
         onCommandInvoked: suspend InteractionScope.() -> Unit,
-        builder: ChatInputCommandBuilder.() -> Unit,
+        builder: CommandBuilder.() -> Unit,
     ) {
         restClient.interaction.createGlobalChatInputApplicationCommand(
             restClient.application.getCurrentApplicationInfo().id,
             name,
             description,
-        ) { KordChatInputCommandBuilder(this).apply(builder) }
+        ) { KordCommandBuilder(this).apply(builder) }
 
         scope.launch {
             gateway.events
@@ -52,5 +53,17 @@ internal class KordApplicationCommandScope(
                     interactionScope.onCommandInvoked()
                 }
         }
+    }
+
+    override suspend fun registerGlobalChatInputCommandGroup(
+        name: String,
+        description: String,
+        builder: CommandGroupBuilder.() -> Unit
+    ) {
+        restClient.interaction.createGlobalChatInputApplicationCommand(
+            restClient.application.getCurrentApplicationInfo().id,
+            name,
+            description,
+        ) { KordCommandGroupBuilder(this).apply(builder) }
     }
 }

--- a/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
@@ -79,7 +79,6 @@ internal class KordApplicationCommandScope(
                 .filterIsInstance<InteractionCreate>()
                 .collectLatest {
                     if (it.interaction.data.name.value == name) {
-                        // Command group
                         val commandGroup = it.interaction.data.options.value?.filterIsInstance<CommandGroup>()?.firstOrNull()
                         var fullCommandName = ""
                         val command = if (commandGroup != null) {
@@ -89,7 +88,7 @@ internal class KordApplicationCommandScope(
                             it.interaction.data.options.value?.first() as SubCommand
                         }
                         fullCommandName += " ${command.name}"
-                        fullCommandName = fullCommandName.trimStart()
+                        fullCommandName = fullCommandName.trim()
 
                         println(fullCommandName)
                         println(commandInvokeCallbacks.keys)

--- a/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
@@ -61,7 +61,7 @@ internal class KordApplicationCommandScope(
     override suspend fun registerGlobalChatInputCommandGroup(
         name: String,
         description: String,
-        builder: CommandGroupBuilder.() -> Unit
+        builder: CommandGroupBuilder.() -> Unit,
     ) {
         var commandInvokeCallbacks: Map<String, suspend InteractionScope.() -> Unit>
         restClient.interaction.createGlobalChatInputApplicationCommand(

--- a/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordApplicationCommandScope.kt
@@ -79,7 +79,9 @@ internal class KordApplicationCommandScope(
                 .filterIsInstance<InteractionCreate>()
                 .collectLatest {
                     if (it.interaction.data.name.value == name) {
-                        val commandGroup = it.interaction.data.options.value?.filterIsInstance<CommandGroup>()?.firstOrNull()
+                        val commandGroup = it.interaction.data.options.value
+                            ?.filterIsInstance<CommandGroup>()
+                            ?.firstOrNull()
                         var fullCommandName = ""
                         val command = if (commandGroup != null) {
                             fullCommandName += commandGroup.name

--- a/core/discord/src/main/kotlin/kord/interaction/KordCommandBuilder.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordCommandBuilder.kt
@@ -31,7 +31,6 @@ import interaction.CommandGroupBuilder
 import interaction.InteractionScope
 import interaction.SubCommandBuilder
 import interaction.SubCommandGroupBuilder
-import kotlinx.coroutines.CoroutineScope
 
 internal class KordCommandBuilder(
     private val kordBuilder: GlobalChatInputCreateBuilder,
@@ -71,11 +70,10 @@ internal class KordCommandBuilder(
         kordBuilder.number(name, description) {
             this.required = required
         }
-
 }
 
 internal class KordCommandGroupBuilder(
-    private val kordBuilder: GlobalChatInputCreateBuilder
+    private val kordBuilder: GlobalChatInputCreateBuilder,
 ) : CommandGroupBuilder {
 
     val commandInvokeCallbacks = mutableMapOf<String, suspend InteractionScope.() -> Unit>()
@@ -84,7 +82,7 @@ internal class KordCommandGroupBuilder(
         name: String,
         description: String,
         onCommandInvoked: suspend InteractionScope.() -> Unit,
-        builder: SubCommandBuilder.() -> Unit
+        builder: SubCommandBuilder.() -> Unit,
     ) {
         kordBuilder.subCommand(name, description) {
             KordSubCommandBuilder(this).apply(builder)
@@ -98,7 +96,7 @@ internal class KordCommandGroupBuilder(
                 commandInvokeCallbacks.putAll(
                     it.commandInvokeCallbacks.mapKeys {
                         "$name ${it.key}"
-                    }
+                    },
                 )
             }
         }
@@ -155,7 +153,7 @@ internal class KordSubCommandGroupBuilder(
         name: String,
         description: String,
         onCommandInvoked: suspend InteractionScope.() -> Unit,
-        builder: SubCommandBuilder.() -> Unit
+        builder: SubCommandBuilder.() -> Unit,
     ) {
         kordBuilder.subCommand(name, description) {
             KordSubCommandBuilder(this).apply(builder)

--- a/core/discord/src/main/kotlin/kord/interaction/KordCommandBuilder.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordCommandBuilder.kt
@@ -26,13 +26,14 @@ import dev.kord.rest.builder.interaction.number
 import dev.kord.rest.builder.interaction.string
 import dev.kord.rest.builder.interaction.subCommand
 import dev.kord.rest.builder.interaction.user
-import interaction.ChatInputCommandBuilder
+import interaction.CommandBuilder
+import interaction.CommandGroupBuilder
 import interaction.SubCommandBuilder
 import interaction.SubCommandGroupBuilder
 
-internal class KordChatInputCommandBuilder(
+internal class KordCommandBuilder(
     private val kordBuilder: GlobalChatInputCreateBuilder,
-) : ChatInputCommandBuilder {
+) : CommandBuilder {
 
     override fun int(name: String, description: String, required: Boolean) =
         kordBuilder.int(name, description) {
@@ -69,6 +70,11 @@ internal class KordChatInputCommandBuilder(
             this.required = required
         }
 
+}
+
+internal class KordCommandGroupBuilder(
+    private val kordBuilder: GlobalChatInputCreateBuilder
+) : CommandGroupBuilder {
     override fun subCommand(name: String, description: String, builder: SubCommandBuilder.() -> Unit) =
         kordBuilder.subCommand(name, description) {
             KordSubCommandBuilder(this).apply(builder)

--- a/core/discord/src/main/kotlin/kord/interaction/KordCommandBuilder.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordCommandBuilder.kt
@@ -28,6 +28,7 @@ import dev.kord.rest.builder.interaction.subCommand
 import dev.kord.rest.builder.interaction.user
 import interaction.CommandBuilder
 import interaction.CommandGroupBuilder
+import interaction.InteractionScope
 import interaction.SubCommandBuilder
 import interaction.SubCommandGroupBuilder
 
@@ -75,7 +76,12 @@ internal class KordCommandBuilder(
 internal class KordCommandGroupBuilder(
     private val kordBuilder: GlobalChatInputCreateBuilder
 ) : CommandGroupBuilder {
-    override fun subCommand(name: String, description: String, builder: SubCommandBuilder.() -> Unit) =
+    override fun subCommand(
+        name: String,
+        description: String,
+        onCommandInvoked: suspend InteractionScope.() -> Unit,
+        builder: SubCommandBuilder.() -> Unit
+    ) =
         kordBuilder.subCommand(name, description) {
             KordSubCommandBuilder(this).apply(builder)
         }
@@ -129,7 +135,12 @@ internal class KordSubCommandBuilder(
 internal class KordSubCommandGroupBuilder(
     private val kordBuilder: GroupCommandBuilder,
 ) : SubCommandGroupBuilder {
-    override fun subCommand(name: String, description: String, builder: SubCommandBuilder.() -> Unit) =
+    override fun subCommand(
+        name: String,
+        description: String,
+        onCommandInvoked: suspend InteractionScope.() -> Unit,
+        builder: SubCommandBuilder.() -> Unit
+    ) =
         kordBuilder.subCommand(name, description) {
             KordSubCommandBuilder(this).apply(builder)
         }

--- a/core/discord/src/main/kotlin/kord/interaction/KordInteractionScope.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordInteractionScope.kt
@@ -26,6 +26,11 @@ internal class KordInteractionScope(
     private val restClient: RestClient,
     private val interaction: InteractionCreate,
 ) : InteractionScope {
+
+    override val sourceGuildId: String? = interaction.interaction.guildId.value?.toString()
+
+    override val sourceChannelId: String = interaction.interaction.channelId.toString()
+
     override suspend fun createResponseMessage(targetChannelId: String, ephemeral: Boolean, content: String) {
         restClient.interaction.createInteractionResponse(
             interaction.interaction.id,

--- a/core/discord/src/main/kotlin/kord/interaction/KordInteractionScope.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordInteractionScope.kt
@@ -17,7 +17,6 @@ package kord.interaction
 
 import dev.kord.common.entity.CommandArgument
 import dev.kord.common.entity.CommandGroup
-import dev.kord.common.entity.Option
 import dev.kord.common.entity.SubCommand
 import dev.kord.gateway.InteractionCreate
 import dev.kord.rest.service.RestClient

--- a/core/discord/src/main/kotlin/kord/interaction/KordInteractionScope.kt
+++ b/core/discord/src/main/kotlin/kord/interaction/KordInteractionScope.kt
@@ -15,6 +15,10 @@
  */
 package kord.interaction
 
+import dev.kord.common.entity.CommandArgument
+import dev.kord.common.entity.CommandGroup
+import dev.kord.common.entity.Option
+import dev.kord.common.entity.SubCommand
 import dev.kord.gateway.InteractionCreate
 import dev.kord.rest.service.RestClient
 import interaction.InteractionScope
@@ -31,5 +35,30 @@ internal class KordInteractionScope(
         ) {
             this.content = content
         }
+    }
+
+    override fun getChannelId(optionName: String): String {
+        // Try to get the value from the first command segment
+        interaction.interaction.data.options.value?.first { it.name == optionName }?.also {
+            if (it is CommandArgument.ChannelArgument) {
+                return it.value.toString()
+            }
+        }
+
+        // Get possible values
+        val commandGroup = interaction.interaction.data.options.value?.filterIsInstance<CommandGroup>()?.firstOrNull()
+        val subCommand: SubCommand = if (commandGroup != null) {
+            // If we have a command group, we have a nested subcommand
+            commandGroup.options.value?.first() as SubCommand
+        } else {
+            // Else we just have a subcommand
+            interaction.interaction.data.options.value?.filterIsInstance<SubCommand>()?.firstOrNull() as SubCommand
+        }
+
+        return subCommand.options.value!!
+            .filterIsInstance<CommandArgument.ChannelArgument>()
+            .first { it.name == optionName }
+            .value
+            .toString()
     }
 }


### PR DESCRIPTION
The previous implementation rendered callbacks for any kind of subcommand entirely inoperable. This aims to fix that, as well as providing a mechanism for retrieving options