### PR TITLE
Temporary fix for incorrect links

### DIFF
--- a/dale/src/main/kotlin/dale/studio/AndroidStudioUpdateFeature.kt
+++ b/dale/src/main/kotlin/dale/studio/AndroidStudioUpdateFeature.kt
@@ -143,7 +143,7 @@ class AndroidStudioUpdateFeature(
                                 title = newUpdate.title
                                 // description = newUpdate.content
                                 timestamp = newUpdate.publishedOn.toInstant().toKotlinInstant()
-                                url = newUpdate.links.firstOrNull()?.url
+                                url = newUpdate.links.lastOrNull()?.url
                                 author(newUpdate.author.name, null, null)
                             }
                         Channel.Type.GUILD_FORUM ->
@@ -151,7 +151,7 @@ class AndroidStudioUpdateFeature(
                                 title = newUpdate.title
                                 // description = newUpdate.content
                                 timestamp = newUpdate.publishedOn.toInstant().toKotlinInstant()
-                                url = newUpdate.links.firstOrNull()?.url
+                                url = newUpdate.links.lastOrNull()?.url
                                 author(newUpdate.author.name, null, null)
                             }
                         Channel.Type.ANNOUNCEMENT_THREAD,


### PR DESCRIPTION
Looking at the blog posts, the last URL *should* be what we want. Long-term we should probably find some way of matching the appropriate one 100% of the time