### PR TITLE
Improve version extraction logic

### DIFF
--- a/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/AndroidStudioUpdateFeature.kt
+++ b/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/AndroidStudioUpdateFeature.kt
@@ -155,7 +155,7 @@ class AndroidStudioUpdateFeature(
     ) {
         when (channel) {
             is MessageChannel -> channel.createEmbed {
-                title = update.version
+                title = "Android Studio ${update.version}"
                 description = update.summary
                 timestamp = update.timestamp
                 url = update.url
@@ -163,7 +163,7 @@ class AndroidStudioUpdateFeature(
             is ForumChannel -> channel.startPublicThread(name = update.version) {
                 message {
                     embed {
-                        title = update.version
+                        title = "Android Studio ${update.version}"
                         description = update.summary
                         timestamp = update.timestamp
                         url = update.url

--- a/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSource.kt
+++ b/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSource.kt
@@ -81,6 +81,8 @@ internal class AndroidStudioBlogUpdateSource(
             title.contains("available") -> title.split("available").first()
             else -> error("Unknown title format $title")
         }.trim()
+            .removePrefix("Android Studio ")
+            .replace(Regex(" \\| \\d\\d\\d\\d\\.\\d\\.\\d"), "")
     }
 
     internal fun extractChannelFromTitle(title: String): AndroidStudioUpdate.UpdateChannel {

--- a/features/android-studio-updates/src/test/java/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSourceTest.kt
+++ b/features/android-studio-updates/src/test/java/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSourceTest.kt
@@ -25,24 +25,28 @@ class AndroidStudioBlogUpdateSourceTest {
     @Test
     fun text_extractVersionFromTitle() {
         assertEquals(
-            "Android Studio Giraffe Canary 9",
+            "Giraffe Canary 9",
             testSubject.extractVersionFromTitle("Android Studio Giraffe Canary 9 now available"),
         )
         assertEquals(
-            "Android Studio Flamingo Beta 5",
+            "Flamingo Beta 5",
             testSubject.extractVersionFromTitle("Android Studio Flamingo Beta 5 now available"),
         )
         assertEquals(
-            "Android Studio Flamingo Beta 3",
+            "Flamingo Beta 3",
             testSubject.extractVersionFromTitle("Android Studio Flamingo Beta 3 is now available"),
         )
         assertEquals(
-            "Android Studio Electric Eel | 2022.1.1 Patch 1",
+            "Electric Eel Patch 1",
             testSubject.extractVersionFromTitle("Android Studio Electric Eel | 2022.1.1 Patch 1 now available"),
         )
         assertEquals(
-            "Android Studio Electric Eel",
+            "Electric Eel",
             testSubject.extractVersionFromTitle("Android Studio Electric Eel available in the Stable channel"),
+        )
+        assertEquals(
+            "Hedgehog RC 2",
+            testSubject.extractVersionFromTitle("Android Studio Hedgehog | 2023.1.1 RC 2 now available")
         )
     }
 }


### PR DESCRIPTION
We now extract only the relevant version bits (Hedgehog RC 2), rather than the verbose version (Android Studio Hedgehog | 2023.1.1 RC 2)