### PR TITLE
Naively avoid duplicate updates

### DIFF
--- a/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSource.kt
+++ b/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSource.kt
@@ -20,6 +20,7 @@ import features.updates.androidstudio.updatesource.rssfetcher.FetcherFactory
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.drop
 import kotlinx.coroutines.flow.filterNotNull
 import kotlinx.coroutines.flow.merge
 import kotlinx.datetime.toKotlinInstant
@@ -43,7 +44,7 @@ internal class AndroidStudioBlogUpdateSource(
             latestReleaseCandidateUpdate.filterNotNull(),
             latestBetaUpdate.filterNotNull(),
             latestCanaryUpdate.filterNotNull(),
-        )
+        ).drop(4)
 
     override suspend fun checkForUpdates() {
         val feed = source.obtainFeed("https://androidstudio.googleblog.com/feeds/posts/default")

--- a/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSource.kt
+++ b/features/android-studio-updates/src/main/kotlin/features/updates/androidstudio/updatesource/AndroidStudioBlogUpdateSource.kt
@@ -44,7 +44,7 @@ internal class AndroidStudioBlogUpdateSource(
             latestReleaseCandidateUpdate.filterNotNull(),
             latestBetaUpdate.filterNotNull(),
             latestCanaryUpdate.filterNotNull(),
-        ).drop(4)
+        ).drop(AndroidStudioUpdate.UpdateChannel.entries.count())
 
     override suspend fun checkForUpdates() {
         val feed = source.obtainFeed("https://androidstudio.googleblog.com/feeds/posts/default")


### PR DESCRIPTION
This simply drops the first 4 updates from the latestUpdate Flow, i.e. the fresh set of loaded updates on startup.

This also means if there were new updates while the bot was down, they won't be posted.